### PR TITLE
Add Travis CI deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+
+language: bash
+services: docker
+
+env:
+  global:
+    - GCG_VERSION=v1.14.3
+
+script:
+  - ./scripts/cibuild
+
+deploy:
+  - provider: script
+    script: "scripts/cipublish"
+    on:
+      repo: azavea/docker-github-changelog-generator
+      branch: master

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,0 +1,13 @@
+FROM ruby:2
+
+RUN set -ex \
+	&& mkdir -p /opt/changelog-generator \
+	&& wget -qO- https://github.com/azavea/github-changelog-generator/archive/%%GCG_VERSION%%-azavea.tar.gz | \
+	   tar --strip-components=1 -xzC /opt/changelog-generator \
+ 	&& cd /opt/changelog-generator \
+ 	&& gem install -N bundler \
+ 	&& bundle install \
+ 	&& gem build github_changelog_generator \
+ 	&& gem install -N *.gem
+
+ENTRYPOINT ["github_changelog_generator"]

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017 Azavea, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# docker-github-changelog-generator
+
+This repository contains a collection of templated `Dockerfile` for image variants designed to build GitHub Changelogs using the [github-changelog-generator](https://github.com/azavea/github-changelog-generator), and drive deployments with Terraform and AWS.
+
+## Usage
+
+### Template Variables
+
+- `GCG_VERSION` - Version number of the GitHub Changelog Generator
+- `TERRAFORM_VERSION` - Terraform version
+
+### Testing
+
+An example of how to use `cibuild` to build and test an image:
+
+```bash
+$ CI=1 GCG_VERSION=v1.14.3 TERRAFORM_VERSION=0.9.6 \
+  ./scripts/cibuild
+```

--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
 # docker-github-changelog-generator
 
-This repository contains a collection of templated `Dockerfile` for image variants designed to build GitHub Changelogs using the [github-changelog-generator](https://github.com/azavea/github-changelog-generator), and drive deployments with Terraform and AWS.
+This repository contains a collection of templated `Dockerfile` for image variants designed to build GitHub Changelogs using the [github-changelog-generator](https://github.com/azavea/github-changelog-generator).
 
 ## Usage
 
 ### Template Variables
 
 - `GCG_VERSION` - Version number of the GitHub Changelog Generator
-- `TERRAFORM_VERSION` - Terraform version
 
 ### Testing
 
 An example of how to use `cibuild` to build and test an image:
 
 ```bash
-$ CI=1 GCG_VERSION=v1.14.3 TERRAFORM_VERSION=0.9.6 \
-  ./scripts/cibuild
+$ CI=1 GCG_VERSION=v1.14.3 ./scripts/cibuild
 ```

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${CI}" ]]; then
+    set -x
+fi
+
+set -u
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Build container images from templates.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        sed -e "s/%%GCG_VERSION%%/${GCG_VERSION}/" \
+            "Dockerfile.template" > Dockerfile
+        docker \
+            build -t "quay.io/azavea/github-changelog-generator:${GCG_VERSION}" .
+
+
+        ./scripts/test
+
+        docker images
+    fi
+fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+set -u
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Publish container images built from templates.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        docker \
+            login -u "${QUAY_USER}" -p "${QUAY_PASSWORD}" quay.io
+
+        docker \
+            push "quay.io/azavea/github-changelog-generator:${GCG_VERSION}"
+    fi
+fi

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${CI}" ]]; then
+    set -x
+fi
+
+set -u
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Test container images built from templates.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+
+        docker run --rm -it \
+         "quay.io/azavea/github-changelog-generator:${GCG_VERSION}" \
+         --help | grep "Usage: github_changelog_generator"
+
+    fi
+fi


### PR DESCRIPTION
# Overview

Add resources to test, build, and deploy container images to Quay, from CI:
  -Travis CI configuration
  - Dockerfile template
   -`scripts/cibuild`, `scripts/test`, `scripts/cibpublish`

Also, sign the LICENSE and add a README to this project.

# Testing
See raster-foundry/raster-foundry#2456 and [Travis CI output](https://travis-ci.org/azavea/docker-github-changelog-generator/builds/268487098)

Closes azavea/operations#98